### PR TITLE
[Feature] Add get current workdir functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: test
+test:
+	go test -v -race -buildvcs
+
+.PHONY: bench
+bench:
+	go test -bench .

--- a/error.go
+++ b/error.go
@@ -1,0 +1,7 @@
+package osx
+
+import "errors"
+
+var (
+	ErrUnrecoverableWorkdir = errors.New("osx: unable to get the current working directory")
+)

--- a/osx.go
+++ b/osx.go
@@ -1,1 +1,15 @@
 package osx
+
+import (
+	"path"
+	"runtime"
+)
+
+func Workdir() (string, error) {
+	_, filename, _, ok := runtime.Caller(1)
+	if !ok {
+		return "", ErrUnrecoverableWorkdir
+	}
+	dir := path.Dir(filename)
+	return dir, nil
+}

--- a/osx.go
+++ b/osx.go
@@ -5,6 +5,10 @@ import (
 	"runtime"
 )
 
+// Get current working directory by recovering the information of the file caller.
+// After getting the filename, retrieve the corresponding directory it live and
+// then return the absolute path of that directory. It will return an error if it
+// fails to retrieve the filename.
 func Workdir() (string, error) {
 	_, filename, _, ok := runtime.Caller(1)
 	if !ok {

--- a/osx_test.go
+++ b/osx_test.go
@@ -1,0 +1,16 @@
+package osx
+
+import (
+	"testing"
+)
+
+func TestWorkdir(t *testing.T) {
+	wd, err := Workdir()
+	if err != nil {
+		t.Fatalf("expected: %v\nactual: %s", nil, err)
+	}
+
+	if len(wd) == 0 {
+		t.Errorf("expected: %v\nactual: %s", "not empty", wd)
+	}
+}

--- a/osx_test.go
+++ b/osx_test.go
@@ -14,3 +14,12 @@ func TestWorkdir(t *testing.T) {
 		t.Errorf("expected: %v\nactual: %s", "not empty", wd)
 	}
 }
+
+func BenchmarkWorkdir(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _ = Workdir()
+	}
+}


### PR DESCRIPTION
## Description

Added get current working directory functionality. It retrieve current workdir by retrieving the file caller name then get the directory where that file live.

## Changes introduced

- [x] Workdir functionality
- [x] Workdir short function documentation
- [x] Workdir test case with benchmark 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Code consistency (non-breaking change which improves code reliability and robustness)

## Checklist

- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [x] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [x] Ensured that new and existing unit tests pass locally with the changes.
- [x] Provided benchmarks for the new code to analyze and improve upon.
